### PR TITLE
Make mocha a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
     "reporter",
     "fivemat"
   ],
-  "dependencies": {
-    "mocha": "^2.4.2"
-  },
   "author": "Darshan Sawardekar",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/dsawardekar/mocha-fivemat-reporter/issues"
+  },
+  "peerDependencies": {
+    "mocha": "*"
   },
   "devDependencies": {
     "grunt-release": "~0.6.0"


### PR DESCRIPTION
The currently published version of the module is being flagged by `npm audit` as having critical defects due to the version of mocha specified in package.json.

This patch intends to make the version of mocha a non-issue.